### PR TITLE
Update Cake

### DIFF
--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.14" />
+    <package id="Cake" version="0.15" />
 </packages>


### PR DESCRIPTION
Update to Cake v15, which should fix the mono 3.2.8 build.
