### PR TITLE
 #14 Erroneous TeamCity service messages with multiple test assemblies and (default) parallel execution

### DIFF
--- a/src/extension/teamcity-event-listener.csproj
+++ b/src/extension/teamcity-event-listener.csproj
@@ -16,7 +16,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\bin\nunit\NUnit.Extension.TeamCityEventListener\tools\</OutputPath>
+    <OutputPath>..\..\..\nunit-console\bin\Debug\addins\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/src/nunit.integration.tests/RunTests.feature
+++ b/src/nunit.integration.tests/RunTests.feature
@@ -47,17 +47,6 @@ Scenario Outline: User runs tests for several assemblies
 
 Examples:
 	| frameworkVersion | process   | domain   | agents | platform | configurationType |
-	| Version45        | InProcess | Single   | 10     | AnyCpu   | ProjectFile       |
-	| Version40        | InProcess | Single   | 10     | AnyCpu   | ProjectFile       |
-	| Version45        | Separate  | Single   | 10     | AnyCpu   | ProjectFile       |
-	| Version40        | Separate  | Single   | 10     | AnyCpu   | ProjectFile       |
-	| Version45        | Multiple  | Single   | 10     | AnyCpu   | ProjectFile       |
-	| Version40        | Multiple  | Single   | 10     | AnyCpu   | ProjectFile       |
-	| Version45        | InProcess | Multiple | 10     | AnyCpu   | ProjectFile       |
-	| Version40        | InProcess | Multiple | 10     | AnyCpu   | ProjectFile       |
-	| Version45        | Separate  | Multiple | 10     | AnyCpu   | ProjectFile       |
-	| Version40        | Separate  | Multiple | 10     | AnyCpu   | ProjectFile       |
-	| Version45        | InProcess | Single   | 10     | AnyCpu   | ProjectFile       |
 	| Version40        | InProcess | Single   | 2      | AnyCpu   | ProjectFile       |
 	| Version45        | Separate  | Single   | 2      | AnyCpu   | ProjectFile       |
 	| Version40        | Separate  | Single   | 2      | AnyCpu   | ProjectFile       |
@@ -98,17 +87,6 @@ Examples:
 	| Version40        | InProcess | Multiple | 2      | X86      | ProjectFile       |
 	| Version45        | Separate  | Multiple | 2      | X86      | ProjectFile       |
 	| Version40        | Separate  | Multiple | 2      | X86      | ProjectFile       |
-	| Version45        | InProcess | Single   | 10     | AnyCpu   | CmdArguments      |
-	| Version40        | InProcess | Single   | 10     | AnyCpu   | CmdArguments      |
-	| Version45        | Separate  | Single   | 10     | AnyCpu   | CmdArguments      |
-	| Version40        | Separate  | Single   | 10     | AnyCpu   | CmdArguments      |
-	| Version45        | Multiple  | Single   | 10     | AnyCpu   | CmdArguments      |
-	| Version40        | Multiple  | Single   | 10     | AnyCpu   | CmdArguments      |
-	| Version45        | InProcess | Multiple | 10     | AnyCpu   | CmdArguments      |
-	| Version40        | InProcess | Multiple | 10     | AnyCpu   | CmdArguments      |
-	| Version45        | Separate  | Multiple | 10     | AnyCpu   | CmdArguments      |
-	| Version40        | Separate  | Multiple | 10     | AnyCpu   | CmdArguments      |
-	| Version45        | InProcess | Single   | 10     | AnyCpu   | CmdArguments      |
 	| Version40        | InProcess | Single   | 2      | AnyCpu   | CmdArguments      |
 	| Version45        | Separate  | Single   | 2      | AnyCpu   | CmdArguments      |
 	| Version40        | Separate  | Single   | 2      | AnyCpu   | CmdArguments      |
@@ -128,9 +106,6 @@ Examples:
 	| Version40        | InProcess | Multiple | 1      | AnyCpu   | CmdArguments      |
 	| Version45        | Separate  | Multiple | 1      | AnyCpu   | CmdArguments      |
 	| Version40        | Separate  | Multiple | 1      | AnyCpu   | CmdArguments      |
-	| Version45        | Separate  | Single   | 10     | X86      | CmdArguments      |
-	| Version40        | Separate  | Single   | 10     | X86      | CmdArguments      |
-	| Version45        | Multiple  | Single   | 10     | X86      | CmdArguments      |
 	| Version40        | Multiple  | Single   | 10     | X86      | CmdArguments      |
 	| Version45        | Separate  | Multiple | 10     | X86      | CmdArguments      |
 	| Version40        | Separate  | Multiple | 10     | X86      | CmdArguments      |

--- a/src/nunit.integration.tests/RunTests.feature
+++ b/src/nunit.integration.tests/RunTests.feature
@@ -3,6 +3,153 @@
 Background:
 	Given NUnit path is ..\nunit\
 
+Scenario Outline: User runs tests for several assemblies
+	Given Framework version is <frameworkVersion>
+	And I have created the folder mocks
+	And I have copied NUnit framework references to folder mocks
+	And I have added successful method as SuccessfulTest to the class Foo.Tests.UnitTests1 for foo.tests	
+	And I have added NUnit framework references to foo.tests	
+	
+	And I have compiled the assembly foo.tests to file mocks\foo1.tests.dll
+	And I have added the assembly mocks\foo1.tests.dll to the list of testing assemblies
+
+	And I have compiled the assembly foo.tests to file mocks\foo2.tests.dll
+	And I have added the assembly mocks\foo2.tests.dll to the list of testing assemblies
+
+	And I have compiled the assembly foo.tests to file mocks\foo3.tests.dll
+	And I have added the assembly mocks\foo3.tests.dll to the list of testing assemblies
+
+	And I have compiled the assembly foo.tests to file mocks\foo4.tests.dll
+	And I have added the assembly mocks\foo4.tests.dll to the list of testing assemblies
+
+	And I have compiled the assembly foo.tests to file mocks\foo5.tests.dll
+	And I have added the assembly mocks\foo5.tests.dll to the list of testing assemblies
+
+	And I have compiled the assembly foo.tests to file mocks\foo6.tests.dll
+	And I have added the assembly mocks\foo6.tests.dll to the list of testing assemblies
+	
+	And I want to use <configurationType> configuration type
+	And I have added the arg workers=10 to NUnit console command line
+	And I have added the arg agents=<agents> to NUnit console command line
+	And I have added the arg process=<process> to NUnit console command line
+	And I have added the arg domain=<domain> to NUnit console command line
+
+	When I run NUnit console
+	Then the exit code should be 0
+	And the output should contain correct set of TeamCity service messages
+	And the Test Run Summary should has following:
+	| field        | value |
+	| Test Count   | 6     |
+	| Passed       | 6     |
+	| Failed       | 0     |
+	| Inconclusive | 0     |
+	| Skipped      | 0     |
+
+Examples:
+	| frameworkVersion | process   | domain   | agents | platform | configurationType |
+	| Version45        | InProcess | Single   | 10     | AnyCpu   | ProjectFile       |
+	| Version40        | InProcess | Single   | 10     | AnyCpu   | ProjectFile       |
+	| Version45        | Separate  | Single   | 10     | AnyCpu   | ProjectFile       |
+	| Version40        | Separate  | Single   | 10     | AnyCpu   | ProjectFile       |
+	| Version45        | Multiple  | Single   | 10     | AnyCpu   | ProjectFile       |
+	| Version40        | Multiple  | Single   | 10     | AnyCpu   | ProjectFile       |
+	| Version45        | InProcess | Multiple | 10     | AnyCpu   | ProjectFile       |
+	| Version40        | InProcess | Multiple | 10     | AnyCpu   | ProjectFile       |
+	| Version45        | Separate  | Multiple | 10     | AnyCpu   | ProjectFile       |
+	| Version40        | Separate  | Multiple | 10     | AnyCpu   | ProjectFile       |
+	| Version45        | InProcess | Single   | 10     | AnyCpu   | ProjectFile       |
+	| Version40        | InProcess | Single   | 2      | AnyCpu   | ProjectFile       |
+	| Version45        | Separate  | Single   | 2      | AnyCpu   | ProjectFile       |
+	| Version40        | Separate  | Single   | 2      | AnyCpu   | ProjectFile       |
+	| Version45        | Multiple  | Single   | 2      | AnyCpu   | ProjectFile       |
+	| Version40        | Multiple  | Single   | 2      | AnyCpu   | ProjectFile       |
+	| Version45        | InProcess | Multiple | 2      | AnyCpu   | ProjectFile       |
+	| Version40        | InProcess | Multiple | 2      | AnyCpu   | ProjectFile       |
+	| Version45        | Separate  | Multiple | 2      | AnyCpu   | ProjectFile       |
+	| Version40        | Separate  | Multiple | 2      | AnyCpu   | ProjectFile       |
+	| Version45        | InProcess | Single   | 1      | AnyCpu   | ProjectFile       |
+	| Version40        | InProcess | Single   | 1      | AnyCpu   | ProjectFile       |
+	| Version45        | Separate  | Single   | 1      | AnyCpu   | ProjectFile       |
+	| Version40        | Separate  | Single   | 1      | AnyCpu   | ProjectFile       |
+	| Version45        | Multiple  | Single   | 1      | AnyCpu   | ProjectFile       |
+	| Version40        | Multiple  | Single   | 1      | AnyCpu   | ProjectFile       |
+	| Version45        | InProcess | Multiple | 1      | AnyCpu   | ProjectFile       |
+	| Version40        | InProcess | Multiple | 1      | AnyCpu   | ProjectFile       |
+	| Version45        | Separate  | Multiple | 1      | AnyCpu   | ProjectFile       |
+	| Version40        | Separate  | Multiple | 1      | AnyCpu   | ProjectFile       |
+	| Version45        | Separate  | Single   | 10     | X86      | ProjectFile       |
+	| Version40        | Separate  | Single   | 10     | X86      | ProjectFile       |
+	| Version45        | Multiple  | Single   | 10     | X86      | ProjectFile       |
+	| Version40        | Multiple  | Single   | 10     | X86      | ProjectFile       |
+	| Version45        | Separate  | Multiple | 10     | X86      | ProjectFile       |
+	| Version40        | Separate  | Multiple | 10     | X86      | ProjectFile       |
+	| Version45        | Separate  | Single   | 1      | X86      | ProjectFile       |
+	| Version40        | Separate  | Single   | 1      | X86      | ProjectFile       |
+	| Version45        | Multiple  | Single   | 1      | X86      | ProjectFile       |
+	| Version40        | Multiple  | Single   | 1      | X86      | ProjectFile       |
+	| Version45        | Separate  | Multiple | 1      | X86      | ProjectFile       |
+	| Version40        | Separate  | Multiple | 1      | X86      | ProjectFile       |
+	| Version40        | InProcess | Single   | 2      | X86      | ProjectFile       |
+	| Version45        | Separate  | Single   | 2      | X86      | ProjectFile       |
+	| Version40        | Separate  | Single   | 2      | X86      | ProjectFile       |
+	| Version45        | Multiple  | Single   | 2      | X86      | ProjectFile       |
+	| Version40        | Multiple  | Single   | 2      | X86      | ProjectFile       |
+	| Version45        | InProcess | Multiple | 2      | X86      | ProjectFile       |
+	| Version40        | InProcess | Multiple | 2      | X86      | ProjectFile       |
+	| Version45        | Separate  | Multiple | 2      | X86      | ProjectFile       |
+	| Version40        | Separate  | Multiple | 2      | X86      | ProjectFile       |
+	| Version45        | InProcess | Single   | 10     | AnyCpu   | CmdArguments      |
+	| Version40        | InProcess | Single   | 10     | AnyCpu   | CmdArguments      |
+	| Version45        | Separate  | Single   | 10     | AnyCpu   | CmdArguments      |
+	| Version40        | Separate  | Single   | 10     | AnyCpu   | CmdArguments      |
+	| Version45        | Multiple  | Single   | 10     | AnyCpu   | CmdArguments      |
+	| Version40        | Multiple  | Single   | 10     | AnyCpu   | CmdArguments      |
+	| Version45        | InProcess | Multiple | 10     | AnyCpu   | CmdArguments      |
+	| Version40        | InProcess | Multiple | 10     | AnyCpu   | CmdArguments      |
+	| Version45        | Separate  | Multiple | 10     | AnyCpu   | CmdArguments      |
+	| Version40        | Separate  | Multiple | 10     | AnyCpu   | CmdArguments      |
+	| Version45        | InProcess | Single   | 10     | AnyCpu   | CmdArguments      |
+	| Version40        | InProcess | Single   | 2      | AnyCpu   | CmdArguments      |
+	| Version45        | Separate  | Single   | 2      | AnyCpu   | CmdArguments      |
+	| Version40        | Separate  | Single   | 2      | AnyCpu   | CmdArguments      |
+	| Version45        | Multiple  | Single   | 2      | AnyCpu   | CmdArguments      |
+	| Version40        | Multiple  | Single   | 2      | AnyCpu   | CmdArguments      |
+	| Version45        | InProcess | Multiple | 2      | AnyCpu   | CmdArguments      |
+	| Version40        | InProcess | Multiple | 2      | AnyCpu   | CmdArguments      |
+	| Version45        | Separate  | Multiple | 2      | AnyCpu   | CmdArguments      |
+	| Version40        | Separate  | Multiple | 2      | AnyCpu   | CmdArguments      |
+	| Version45        | InProcess | Single   | 1      | AnyCpu   | CmdArguments      |
+	| Version40        | InProcess | Single   | 1      | AnyCpu   | CmdArguments      |
+	| Version45        | Separate  | Single   | 1      | AnyCpu   | CmdArguments      |
+	| Version40        | Separate  | Single   | 1      | AnyCpu   | CmdArguments      |
+	| Version45        | Multiple  | Single   | 1      | AnyCpu   | CmdArguments      |
+	| Version40        | Multiple  | Single   | 1      | AnyCpu   | CmdArguments      |
+	| Version45        | InProcess | Multiple | 1      | AnyCpu   | CmdArguments      |
+	| Version40        | InProcess | Multiple | 1      | AnyCpu   | CmdArguments      |
+	| Version45        | Separate  | Multiple | 1      | AnyCpu   | CmdArguments      |
+	| Version40        | Separate  | Multiple | 1      | AnyCpu   | CmdArguments      |
+	| Version45        | Separate  | Single   | 10     | X86      | CmdArguments      |
+	| Version40        | Separate  | Single   | 10     | X86      | CmdArguments      |
+	| Version45        | Multiple  | Single   | 10     | X86      | CmdArguments      |
+	| Version40        | Multiple  | Single   | 10     | X86      | CmdArguments      |
+	| Version45        | Separate  | Multiple | 10     | X86      | CmdArguments      |
+	| Version40        | Separate  | Multiple | 10     | X86      | CmdArguments      |
+	| Version45        | Separate  | Single   | 1      | X86      | CmdArguments      |
+	| Version40        | Separate  | Single   | 1      | X86      | CmdArguments      |
+	| Version45        | Multiple  | Single   | 1      | X86      | CmdArguments      |
+	| Version40        | Multiple  | Single   | 1      | X86      | CmdArguments      |
+	| Version45        | Separate  | Multiple | 1      | X86      | CmdArguments      |
+	| Version40        | Separate  | Multiple | 1      | X86      | CmdArguments      |
+	| Version40        | InProcess | Single   | 2      | X86      | CmdArguments      |
+	| Version45        | Separate  | Single   | 2      | X86      | CmdArguments      |
+	| Version40        | Separate  | Single   | 2      | X86      | CmdArguments      |
+	| Version45        | Multiple  | Single   | 2      | X86      | CmdArguments      |
+	| Version40        | Multiple  | Single   | 2      | X86      | CmdArguments      |
+	| Version45        | InProcess | Multiple | 2      | X86      | CmdArguments      |
+	| Version40        | InProcess | Multiple | 2      | X86      | CmdArguments      |
+	| Version45        | Separate  | Multiple | 2      | X86      | CmdArguments      |
+	| Version40        | Separate  | Multiple | 2      | X86      | CmdArguments      |
+
 Scenario Outline: User runs parallelizable tests
 	Given Framework version is <frameworkVersion>
 	And I have added SuccessfulParallelizable method as SuccessfulParallelizable1 to the class Foo.Tests.UnitTests1 for foo1.tests	

--- a/src/nunit.integration.tests/RunTests.feature
+++ b/src/nunit.integration.tests/RunTests.feature
@@ -66,12 +66,6 @@ Examples:
 	| Version40        | InProcess | Multiple | 1      | AnyCpu   | ProjectFile       |
 	| Version45        | Separate  | Multiple | 1      | AnyCpu   | ProjectFile       |
 	| Version40        | Separate  | Multiple | 1      | AnyCpu   | ProjectFile       |
-	| Version45        | Separate  | Single   | 10     | X86      | ProjectFile       |
-	| Version40        | Separate  | Single   | 10     | X86      | ProjectFile       |
-	| Version45        | Multiple  | Single   | 10     | X86      | ProjectFile       |
-	| Version40        | Multiple  | Single   | 10     | X86      | ProjectFile       |
-	| Version45        | Separate  | Multiple | 10     | X86      | ProjectFile       |
-	| Version40        | Separate  | Multiple | 10     | X86      | ProjectFile       |
 	| Version45        | Separate  | Single   | 1      | X86      | ProjectFile       |
 	| Version40        | Separate  | Single   | 1      | X86      | ProjectFile       |
 	| Version45        | Multiple  | Single   | 1      | X86      | ProjectFile       |
@@ -106,9 +100,6 @@ Examples:
 	| Version40        | InProcess | Multiple | 1      | AnyCpu   | CmdArguments      |
 	| Version45        | Separate  | Multiple | 1      | AnyCpu   | CmdArguments      |
 	| Version40        | Separate  | Multiple | 1      | AnyCpu   | CmdArguments      |
-	| Version40        | Multiple  | Single   | 10     | X86      | CmdArguments      |
-	| Version45        | Separate  | Multiple | 10     | X86      | CmdArguments      |
-	| Version40        | Separate  | Multiple | 10     | X86      | CmdArguments      |
 	| Version45        | Separate  | Single   | 1      | X86      | CmdArguments      |
 	| Version40        | Separate  | Single   | 1      | X86      | CmdArguments      |
 	| Version45        | Multiple  | Single   | 1      | X86      | CmdArguments      |
@@ -175,8 +166,6 @@ Examples:
 	| Version40        | InProcess | Multiple | 10     | AnyCpu   |
 	| Version45        | Separate  | Multiple | 10     | AnyCpu   |
 	| Version40        | Separate  | Multiple | 10     | AnyCpu   |
-#	| Version45        | Multiple  | Multiple | 10     | AnyCpu   |
-#	| Version40        | Multiple  | Multiple | 10     | AnyCpu   |
 	| Version45        | InProcess | Single   | 1      | AnyCpu   |
 	| Version40        | InProcess | Single   | 1      | AnyCpu   |
 	| Version45        | Separate  | Single   | 1      | AnyCpu   |
@@ -187,24 +176,18 @@ Examples:
 	| Version40        | InProcess | Multiple | 1      | AnyCpu   |
 	| Version45        | Separate  | Multiple | 1      | AnyCpu   |
 	| Version40        | Separate  | Multiple | 1      | AnyCpu   |
-#	| Version45        | Multiple  | Multiple | 1      | AnyCpu   |
-#	| Version40        | Multiple  | Multiple | 1      | AnyCpu   |
 	| Version45        | Separate  | Single   | 10     | X86     |
 	| Version40        | Separate  | Single   | 10     | X86     |
 	| Version45        | Multiple  | Single   | 10     | X86     |
 	| Version40        | Multiple  | Single   | 10     | X86     |
 	| Version45        | Separate  | Multiple | 10     | X86     |
 	| Version40        | Separate  | Multiple | 10     | X86     |
-#	| Version45        | Multiple  | Multiple | 10     | X86     |
-#	| Version40        | Multiple  | Multiple | 10     | X86     |
 	| Version45        | Separate  | Single   | 1      | X86     |
 	| Version40        | Separate  | Single   | 1      | X86     |
 	| Version45        | Multiple  | Single   | 1      | X86     |
 	| Version40        | Multiple  | Single   | 1      | X86     |
 	| Version45        | Separate  | Multiple | 1      | X86     |
 	| Version40        | Separate  | Multiple | 1      | X86     |
-#	| Version45        | Multiple  | Multiple | 1      | X86     |
-#	| Version40        | Multiple  | Multiple | 1      | X86     |
 
 Scenario Outline: User runs parallelizable tests for NUnit 2 framework
 	And I have added successful method as SuccessfulTest to the class Foo.Tests.UnitTests1 for foo.tests
@@ -256,21 +239,15 @@ Examples:
 	| Version40        | InProcess | Multiple | 1      | AnyCpu   |
 	| Version45        | Separate  | Multiple | 1      | AnyCpu   |
 	| Version40        | Separate  | Multiple | 1      | AnyCpu   |
-#	| Version45        | Multiple  | Multiple | 1      | AnyCpu   |
-#	| Version40        | Multiple  | Multiple | 1      | AnyCpu   |
 	| Version45        | Separate  | Single   | 10     | X86      |
 	| Version40        | Separate  | Single   | 10     | X86      |
 	| Version45        | Multiple  | Single   | 10     | X86      |
 	| Version40        | Multiple  | Single   | 10     | X86      |
 	| Version45        | Separate  | Multiple | 10     | X86      |
 	| Version40        | Separate  | Multiple | 10     | X86      |
-#	| Version45        | Multiple  | Multiple | 10     | X86      |
-#	| Version40        | Multiple  | Multiple | 10     | X86      |
 	| Version45        | Separate  | Single   | 1      | X86      |
 	| Version40        | Separate  | Single   | 1      | X86      |
 	| Version45        | Multiple  | Single   | 1      | X86      |
 	| Version40        | Multiple  | Single   | 1      | X86      |
 	| Version45        | Separate  | Multiple | 1      | X86      |
 	| Version40        | Separate  | Multiple | 1      | X86      |
-#	| Version45        | Multiple  | Multiple | 1      | X86      |
-#	| Version40        | Multiple  | Multiple | 1      | X86      |

--- a/src/nunit.integration.tests/RunTests.feature.cs
+++ b/src/nunit.integration.tests/RunTests.feature.cs
@@ -73,17 +73,6 @@ namespace nunit.integration.tests
         
         [NUnit.Framework.TestAttribute()]
         [NUnit.Framework.DescriptionAttribute("User runs tests for several assemblies")]
-        [NUnit.Framework.TestCaseAttribute("Version45", "InProcess", "Single", "10", "AnyCpu", "ProjectFile", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Single", "10", "AnyCpu", "ProjectFile", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Single", "10", "AnyCpu", "ProjectFile", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Single", "10", "AnyCpu", "ProjectFile", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version45", "Multiple", "Single", "10", "AnyCpu", "ProjectFile", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version40", "Multiple", "Single", "10", "AnyCpu", "ProjectFile", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version45", "InProcess", "Multiple", "10", "AnyCpu", "ProjectFile", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Multiple", "10", "AnyCpu", "ProjectFile", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Multiple", "10", "AnyCpu", "ProjectFile", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Multiple", "10", "AnyCpu", "ProjectFile", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version45", "InProcess", "Single", "10", "AnyCpu", "ProjectFile", new string[0])]
         [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Single", "2", "AnyCpu", "ProjectFile", new string[0])]
         [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Single", "2", "AnyCpu", "ProjectFile", new string[0])]
         [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Single", "2", "AnyCpu", "ProjectFile", new string[0])]
@@ -124,17 +113,6 @@ namespace nunit.integration.tests
         [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Multiple", "2", "X86", "ProjectFile", new string[0])]
         [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Multiple", "2", "X86", "ProjectFile", new string[0])]
         [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Multiple", "2", "X86", "ProjectFile", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version45", "InProcess", "Single", "10", "AnyCpu", "CmdArguments", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Single", "10", "AnyCpu", "CmdArguments", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Single", "10", "AnyCpu", "CmdArguments", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Single", "10", "AnyCpu", "CmdArguments", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version45", "Multiple", "Single", "10", "AnyCpu", "CmdArguments", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version40", "Multiple", "Single", "10", "AnyCpu", "CmdArguments", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version45", "InProcess", "Multiple", "10", "AnyCpu", "CmdArguments", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Multiple", "10", "AnyCpu", "CmdArguments", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Multiple", "10", "AnyCpu", "CmdArguments", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Multiple", "10", "AnyCpu", "CmdArguments", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version45", "InProcess", "Single", "10", "AnyCpu", "CmdArguments", new string[0])]
         [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Single", "2", "AnyCpu", "CmdArguments", new string[0])]
         [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Single", "2", "AnyCpu", "CmdArguments", new string[0])]
         [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Single", "2", "AnyCpu", "CmdArguments", new string[0])]
@@ -154,9 +132,6 @@ namespace nunit.integration.tests
         [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Multiple", "1", "AnyCpu", "CmdArguments", new string[0])]
         [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Multiple", "1", "AnyCpu", "CmdArguments", new string[0])]
         [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Multiple", "1", "AnyCpu", "CmdArguments", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Single", "10", "X86", "CmdArguments", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Single", "10", "X86", "CmdArguments", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version45", "Multiple", "Single", "10", "X86", "CmdArguments", new string[0])]
         [NUnit.Framework.TestCaseAttribute("Version40", "Multiple", "Single", "10", "X86", "CmdArguments", new string[0])]
         [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Multiple", "10", "X86", "CmdArguments", new string[0])]
         [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Multiple", "10", "X86", "CmdArguments", new string[0])]
@@ -295,77 +270,77 @@ this.FeatureBackground();
         public virtual void UserRunsParallelizableTests(string frameworkVersion, string process, string domain, string agents, string platform, string[] exampleTags)
         {
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("User runs parallelizable tests", exampleTags);
-#line 153
+#line 128
 this.ScenarioSetup(scenarioInfo);
 #line 3
 this.FeatureBackground();
-#line 154
+#line 129
  testRunner.Given(string.Format("Framework version is {0}", frameworkVersion), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
-#line 155
+#line 130
  testRunner.And("I have added SuccessfulParallelizable method as SuccessfulParallelizable1 to the " +
                     "class Foo.Tests.UnitTests1 for foo1.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 156
+#line 131
  testRunner.And("I have added SuccessfulParallelizable method as SuccessfulParallelizable2 to the " +
                     "class Foo.Tests.UnitTests1 for foo1.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 157
+#line 132
  testRunner.And("I have added SuccessfulParallelizable method as SuccessfulParallelizable3 to the " +
                     "class Foo.Tests.UnitTests1 for foo1.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 158
+#line 133
  testRunner.And("I have added attribute [assembly: NUnit.Framework.Parallelizable] to the assembly" +
                     " foo1.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 159
+#line 134
  testRunner.And("I have added attribute [NUnit.Framework.Parallelizable] to the class Foo.Tests.Un" +
                     "itTests1 for foo1.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 160
+#line 135
  testRunner.And("I have added NUnit framework references to foo1.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 161
+#line 136
  testRunner.And("I have added SuccessfulParallelizable method as SuccessfulParallelizable4 to the " +
                     "class Foo.Tests.UnitTests1 for foo2.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 162
+#line 137
  testRunner.And("I have added SuccessfulParallelizable method as SuccessfulParallelizable5 to the " +
                     "class Foo.Tests.UnitTests1 for foo2.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 163
+#line 138
  testRunner.And("I have added SuccessfulParallelizable method as SuccessfulParallelizable6 to the " +
                     "class Foo.Tests.UnitTests1 for foo2.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 164
+#line 139
  testRunner.And("I have added attribute [assembly: NUnit.Framework.Parallelizable] to the assembly" +
                     " foo2.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 165
+#line 140
  testRunner.And("I have added attribute [NUnit.Framework.Parallelizable] to the class Foo.Tests.Un" +
                     "itTests1 for foo2.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 166
+#line 141
  testRunner.And("I have added NUnit framework references to foo2.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 167
+#line 142
  testRunner.And("I have created the folder mocks", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 168
+#line 143
  testRunner.And("I have copied NUnit framework references to folder mocks", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 169
+#line 144
  testRunner.And(string.Format("I have specified {0} platform for assembly foo1.tests", platform), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 170
+#line 145
  testRunner.And("I have compiled the assembly foo1.tests to file mocks\\foo1.tests.dll", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 171
+#line 146
  testRunner.And(string.Format("I have specified {0} platform for assembly foo2.tests", platform), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 172
+#line 147
  testRunner.And("I have compiled the assembly foo2.tests to file mocks\\foo2.tests.dll", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 173
+#line 148
  testRunner.And("I have added the assembly mocks\\foo1.tests.dll to the list of testing assemblies", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 174
+#line 149
  testRunner.And("I have added the assembly mocks\\foo2.tests.dll to the list of testing assemblies", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 175
+#line 150
  testRunner.And("I want to use CmdArguments type of TeamCity integration", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 176
+#line 151
  testRunner.And("I have added the arg workers=10 to NUnit console command line", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 177
+#line 152
  testRunner.And(string.Format("I have added the arg agents={0} to NUnit console command line", agents), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 178
+#line 153
  testRunner.And(string.Format("I have added the arg process={0} to NUnit console command line", process), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 179
+#line 154
  testRunner.And(string.Format("I have added the arg domain={0} to NUnit console command line", domain), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 180
+#line 155
  testRunner.When("I run NUnit console", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
-#line 181
+#line 156
  testRunner.Then("the exit code should be 0", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
-#line 182
+#line 157
  testRunner.And("the output should contain correct set of TeamCity service messages", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
             TechTalk.SpecFlow.Table table2 = new TechTalk.SpecFlow.Table(new string[] {
@@ -386,7 +361,7 @@ this.FeatureBackground();
             table2.AddRow(new string[] {
                         "Skipped",
                         "0"});
-#line 183
+#line 158
  testRunner.And("the Test Run Summary should has following:", ((string)(null)), table2, "And ");
 #line hidden
             this.ScenarioCleanup();
@@ -429,47 +404,47 @@ this.FeatureBackground();
         public virtual void UserRunsParallelizableTestsForNUnit2Framework(string frameworkVersion, string process, string domain, string agents, string platform, string[] exampleTags)
         {
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("User runs parallelizable tests for NUnit 2 framework", exampleTags);
-#line 234
+#line 209
 this.ScenarioSetup(scenarioInfo);
 #line 3
 this.FeatureBackground();
-#line 235
+#line 210
  testRunner.And("I have added successful method as SuccessfulTest to the class Foo.Tests.UnitTests" +
                     "1 for foo.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 236
+#line 211
  testRunner.And("I have added successfulCatA method as SuccessfulTestCatA to the class Foo.Tests.U" +
                     "nitTests1 for foo.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 237
+#line 212
  testRunner.And("I have created the folder mocks", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 238
+#line 213
  testRunner.And("I have added the reference ..\\..\\packages\\NUnit.2.6.4\\lib\\nunit.framework.dll to " +
                     "foo.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 239
+#line 214
  testRunner.And("I have copied the reference ..\\..\\packages\\NUnit.2.6.4\\lib\\nunit.framework.dll to" +
                     " folder mocks", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 240
+#line 215
  testRunner.And(string.Format("I have specified {0} platform for assembly foo.tests", platform), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 241
+#line 216
  testRunner.And("I have compiled the assembly foo.tests to file mocks\\foo.tests.dll", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 242
+#line 217
  testRunner.And("I have added the assembly mocks\\foo.tests.dll to the list of testing assemblies", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 243
+#line 218
  testRunner.And("I have added the arg Where=cat!=CatA to NUnit console command line", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 244
+#line 219
  testRunner.And("I want to use CmdArguments type of TeamCity integration", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 245
+#line 220
  testRunner.And("I have added the arg workers=10 to NUnit console command line", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 246
+#line 221
  testRunner.And(string.Format("I have added the arg agents={0} to NUnit console command line", agents), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 247
+#line 222
  testRunner.And(string.Format("I have added the arg process={0} to NUnit console command line", process), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 248
+#line 223
  testRunner.And(string.Format("I have added the arg domain={0} to NUnit console command line", domain), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 249
+#line 224
  testRunner.When("I run NUnit console", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
-#line 250
+#line 225
  testRunner.Then("the exit code should be 0", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
-#line 251
+#line 226
  testRunner.And("the output should contain correct set of TeamCity service messages", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
             TechTalk.SpecFlow.Table table3 = new TechTalk.SpecFlow.Table(new string[] {
@@ -490,7 +465,7 @@ this.FeatureBackground();
             table3.AddRow(new string[] {
                         "Skipped",
                         "0"});
-#line 252
+#line 227
  testRunner.And("the Test Run Summary should has following:", ((string)(null)), table3, "And ");
 #line hidden
             this.ScenarioCleanup();

--- a/src/nunit.integration.tests/RunTests.feature.cs
+++ b/src/nunit.integration.tests/RunTests.feature.cs
@@ -72,6 +72,193 @@ namespace nunit.integration.tests
         }
         
         [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("User runs tests for several assemblies")]
+        [NUnit.Framework.TestCaseAttribute("Version45", "InProcess", "Single", "10", "AnyCpu", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Single", "10", "AnyCpu", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Single", "10", "AnyCpu", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Single", "10", "AnyCpu", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Multiple", "Single", "10", "AnyCpu", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Multiple", "Single", "10", "AnyCpu", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "InProcess", "Multiple", "10", "AnyCpu", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Multiple", "10", "AnyCpu", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Multiple", "10", "AnyCpu", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Multiple", "10", "AnyCpu", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "InProcess", "Single", "10", "AnyCpu", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Single", "2", "AnyCpu", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Single", "2", "AnyCpu", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Single", "2", "AnyCpu", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Multiple", "Single", "2", "AnyCpu", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Multiple", "Single", "2", "AnyCpu", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "InProcess", "Multiple", "2", "AnyCpu", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Multiple", "2", "AnyCpu", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Multiple", "2", "AnyCpu", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Multiple", "2", "AnyCpu", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "InProcess", "Single", "1", "AnyCpu", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Single", "1", "AnyCpu", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Single", "1", "AnyCpu", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Single", "1", "AnyCpu", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Multiple", "Single", "1", "AnyCpu", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Multiple", "Single", "1", "AnyCpu", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "InProcess", "Multiple", "1", "AnyCpu", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Multiple", "1", "AnyCpu", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Multiple", "1", "AnyCpu", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Multiple", "1", "AnyCpu", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Single", "10", "X86", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Single", "10", "X86", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Multiple", "Single", "10", "X86", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Multiple", "Single", "10", "X86", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Multiple", "10", "X86", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Multiple", "10", "X86", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Single", "1", "X86", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Single", "1", "X86", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Multiple", "Single", "1", "X86", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Multiple", "Single", "1", "X86", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Multiple", "1", "X86", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Multiple", "1", "X86", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Single", "2", "X86", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Single", "2", "X86", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Single", "2", "X86", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Multiple", "Single", "2", "X86", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Multiple", "Single", "2", "X86", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "InProcess", "Multiple", "2", "X86", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Multiple", "2", "X86", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Multiple", "2", "X86", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Multiple", "2", "X86", "ProjectFile", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "InProcess", "Single", "10", "AnyCpu", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Single", "10", "AnyCpu", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Single", "10", "AnyCpu", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Single", "10", "AnyCpu", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Multiple", "Single", "10", "AnyCpu", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Multiple", "Single", "10", "AnyCpu", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "InProcess", "Multiple", "10", "AnyCpu", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Multiple", "10", "AnyCpu", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Multiple", "10", "AnyCpu", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Multiple", "10", "AnyCpu", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "InProcess", "Single", "10", "AnyCpu", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Single", "2", "AnyCpu", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Single", "2", "AnyCpu", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Single", "2", "AnyCpu", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Multiple", "Single", "2", "AnyCpu", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Multiple", "Single", "2", "AnyCpu", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "InProcess", "Multiple", "2", "AnyCpu", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Multiple", "2", "AnyCpu", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Multiple", "2", "AnyCpu", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Multiple", "2", "AnyCpu", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "InProcess", "Single", "1", "AnyCpu", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Single", "1", "AnyCpu", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Single", "1", "AnyCpu", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Single", "1", "AnyCpu", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Multiple", "Single", "1", "AnyCpu", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Multiple", "Single", "1", "AnyCpu", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "InProcess", "Multiple", "1", "AnyCpu", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Multiple", "1", "AnyCpu", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Multiple", "1", "AnyCpu", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Multiple", "1", "AnyCpu", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Single", "10", "X86", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Single", "10", "X86", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Multiple", "Single", "10", "X86", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Multiple", "Single", "10", "X86", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Multiple", "10", "X86", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Multiple", "10", "X86", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Single", "1", "X86", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Single", "1", "X86", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Multiple", "Single", "1", "X86", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Multiple", "Single", "1", "X86", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Multiple", "1", "X86", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Multiple", "1", "X86", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Single", "2", "X86", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Single", "2", "X86", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Single", "2", "X86", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Multiple", "Single", "2", "X86", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Multiple", "Single", "2", "X86", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "InProcess", "Multiple", "2", "X86", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Multiple", "2", "X86", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Multiple", "2", "X86", "CmdArguments", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Multiple", "2", "X86", "CmdArguments", new string[0])]
+        public virtual void UserRunsTestsForSeveralAssemblies(string frameworkVersion, string process, string domain, string agents, string platform, string configurationType, string[] exampleTags)
+        {
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("User runs tests for several assemblies", exampleTags);
+#line 6
+this.ScenarioSetup(scenarioInfo);
+#line 3
+this.FeatureBackground();
+#line 7
+ testRunner.Given(string.Format("Framework version is {0}", frameworkVersion), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line 8
+ testRunner.And("I have created the folder mocks", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 9
+ testRunner.And("I have copied NUnit framework references to folder mocks", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 10
+ testRunner.And("I have added successful method as SuccessfulTest to the class Foo.Tests.UnitTests" +
+                    "1 for foo.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 11
+ testRunner.And("I have added NUnit framework references to foo.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 13
+ testRunner.And("I have compiled the assembly foo.tests to file mocks\\foo1.tests.dll", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 14
+ testRunner.And("I have added the assembly mocks\\foo1.tests.dll to the list of testing assemblies", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 16
+ testRunner.And("I have compiled the assembly foo.tests to file mocks\\foo2.tests.dll", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 17
+ testRunner.And("I have added the assembly mocks\\foo2.tests.dll to the list of testing assemblies", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 19
+ testRunner.And("I have compiled the assembly foo.tests to file mocks\\foo3.tests.dll", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 20
+ testRunner.And("I have added the assembly mocks\\foo3.tests.dll to the list of testing assemblies", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 22
+ testRunner.And("I have compiled the assembly foo.tests to file mocks\\foo4.tests.dll", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 23
+ testRunner.And("I have added the assembly mocks\\foo4.tests.dll to the list of testing assemblies", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 25
+ testRunner.And("I have compiled the assembly foo.tests to file mocks\\foo5.tests.dll", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 26
+ testRunner.And("I have added the assembly mocks\\foo5.tests.dll to the list of testing assemblies", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 28
+ testRunner.And("I have compiled the assembly foo.tests to file mocks\\foo6.tests.dll", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 29
+ testRunner.And("I have added the assembly mocks\\foo6.tests.dll to the list of testing assemblies", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 31
+ testRunner.And(string.Format("I want to use {0} configuration type", configurationType), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 32
+ testRunner.And("I have added the arg workers=10 to NUnit console command line", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 33
+ testRunner.And(string.Format("I have added the arg agents={0} to NUnit console command line", agents), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 34
+ testRunner.And(string.Format("I have added the arg process={0} to NUnit console command line", process), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 35
+ testRunner.And(string.Format("I have added the arg domain={0} to NUnit console command line", domain), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 37
+ testRunner.When("I run NUnit console", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 38
+ testRunner.Then("the exit code should be 0", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 39
+ testRunner.And("the output should contain correct set of TeamCity service messages", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            TechTalk.SpecFlow.Table table1 = new TechTalk.SpecFlow.Table(new string[] {
+                        "field",
+                        "value"});
+            table1.AddRow(new string[] {
+                        "Test Count",
+                        "6"});
+            table1.AddRow(new string[] {
+                        "Passed",
+                        "6"});
+            table1.AddRow(new string[] {
+                        "Failed",
+                        "0"});
+            table1.AddRow(new string[] {
+                        "Inconclusive",
+                        "0"});
+            table1.AddRow(new string[] {
+                        "Skipped",
+                        "0"});
+#line 40
+ testRunner.And("the Test Run Summary should has following:", ((string)(null)), table1, "And ");
+#line hidden
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
         [NUnit.Framework.DescriptionAttribute("User runs parallelizable tests")]
         [NUnit.Framework.TestCaseAttribute("Version45", "InProcess", "Single", "10", "AnyCpu", new string[0])]
         [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Single", "10", "AnyCpu", new string[0])]
@@ -108,99 +295,99 @@ namespace nunit.integration.tests
         public virtual void UserRunsParallelizableTests(string frameworkVersion, string process, string domain, string agents, string platform, string[] exampleTags)
         {
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("User runs parallelizable tests", exampleTags);
-#line 6
+#line 153
 this.ScenarioSetup(scenarioInfo);
 #line 3
 this.FeatureBackground();
-#line 7
+#line 154
  testRunner.Given(string.Format("Framework version is {0}", frameworkVersion), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
-#line 8
+#line 155
  testRunner.And("I have added SuccessfulParallelizable method as SuccessfulParallelizable1 to the " +
                     "class Foo.Tests.UnitTests1 for foo1.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 9
+#line 156
  testRunner.And("I have added SuccessfulParallelizable method as SuccessfulParallelizable2 to the " +
                     "class Foo.Tests.UnitTests1 for foo1.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 10
+#line 157
  testRunner.And("I have added SuccessfulParallelizable method as SuccessfulParallelizable3 to the " +
                     "class Foo.Tests.UnitTests1 for foo1.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 11
+#line 158
  testRunner.And("I have added attribute [assembly: NUnit.Framework.Parallelizable] to the assembly" +
                     " foo1.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 12
+#line 159
  testRunner.And("I have added attribute [NUnit.Framework.Parallelizable] to the class Foo.Tests.Un" +
                     "itTests1 for foo1.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 13
+#line 160
  testRunner.And("I have added NUnit framework references to foo1.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 14
+#line 161
  testRunner.And("I have added SuccessfulParallelizable method as SuccessfulParallelizable4 to the " +
                     "class Foo.Tests.UnitTests1 for foo2.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 15
+#line 162
  testRunner.And("I have added SuccessfulParallelizable method as SuccessfulParallelizable5 to the " +
                     "class Foo.Tests.UnitTests1 for foo2.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 16
+#line 163
  testRunner.And("I have added SuccessfulParallelizable method as SuccessfulParallelizable6 to the " +
                     "class Foo.Tests.UnitTests1 for foo2.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 17
+#line 164
  testRunner.And("I have added attribute [assembly: NUnit.Framework.Parallelizable] to the assembly" +
                     " foo2.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 18
+#line 165
  testRunner.And("I have added attribute [NUnit.Framework.Parallelizable] to the class Foo.Tests.Un" +
                     "itTests1 for foo2.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 19
+#line 166
  testRunner.And("I have added NUnit framework references to foo2.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 20
+#line 167
  testRunner.And("I have created the folder mocks", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 21
+#line 168
  testRunner.And("I have copied NUnit framework references to folder mocks", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 22
+#line 169
  testRunner.And(string.Format("I have specified {0} platform for assembly foo1.tests", platform), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 23
+#line 170
  testRunner.And("I have compiled the assembly foo1.tests to file mocks\\foo1.tests.dll", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 24
+#line 171
  testRunner.And(string.Format("I have specified {0} platform for assembly foo2.tests", platform), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 25
+#line 172
  testRunner.And("I have compiled the assembly foo2.tests to file mocks\\foo2.tests.dll", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 26
+#line 173
  testRunner.And("I have added the assembly mocks\\foo1.tests.dll to the list of testing assemblies", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 27
+#line 174
  testRunner.And("I have added the assembly mocks\\foo2.tests.dll to the list of testing assemblies", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 28
+#line 175
  testRunner.And("I want to use CmdArguments type of TeamCity integration", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 29
+#line 176
  testRunner.And("I have added the arg workers=10 to NUnit console command line", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 30
+#line 177
  testRunner.And(string.Format("I have added the arg agents={0} to NUnit console command line", agents), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 31
+#line 178
  testRunner.And(string.Format("I have added the arg process={0} to NUnit console command line", process), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 32
+#line 179
  testRunner.And(string.Format("I have added the arg domain={0} to NUnit console command line", domain), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 33
+#line 180
  testRunner.When("I run NUnit console", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
-#line 34
+#line 181
  testRunner.Then("the exit code should be 0", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
-#line 35
+#line 182
  testRunner.And("the output should contain correct set of TeamCity service messages", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-            TechTalk.SpecFlow.Table table1 = new TechTalk.SpecFlow.Table(new string[] {
+            TechTalk.SpecFlow.Table table2 = new TechTalk.SpecFlow.Table(new string[] {
                         "field",
                         "value"});
-            table1.AddRow(new string[] {
+            table2.AddRow(new string[] {
                         "Test Count",
                         "6"});
-            table1.AddRow(new string[] {
+            table2.AddRow(new string[] {
                         "Passed",
                         "6"});
-            table1.AddRow(new string[] {
+            table2.AddRow(new string[] {
                         "Failed",
                         "0"});
-            table1.AddRow(new string[] {
+            table2.AddRow(new string[] {
                         "Inconclusive",
                         "0"});
-            table1.AddRow(new string[] {
+            table2.AddRow(new string[] {
                         "Skipped",
                         "0"});
-#line 36
- testRunner.And("the Test Run Summary should has following:", ((string)(null)), table1, "And ");
+#line 183
+ testRunner.And("the Test Run Summary should has following:", ((string)(null)), table2, "And ");
 #line hidden
             this.ScenarioCleanup();
         }
@@ -242,69 +429,69 @@ this.FeatureBackground();
         public virtual void UserRunsParallelizableTestsForNUnit2Framework(string frameworkVersion, string process, string domain, string agents, string platform, string[] exampleTags)
         {
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("User runs parallelizable tests for NUnit 2 framework", exampleTags);
-#line 87
+#line 234
 this.ScenarioSetup(scenarioInfo);
 #line 3
 this.FeatureBackground();
-#line 88
+#line 235
  testRunner.And("I have added successful method as SuccessfulTest to the class Foo.Tests.UnitTests" +
                     "1 for foo.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 89
+#line 236
  testRunner.And("I have added successfulCatA method as SuccessfulTestCatA to the class Foo.Tests.U" +
                     "nitTests1 for foo.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 90
+#line 237
  testRunner.And("I have created the folder mocks", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 91
+#line 238
  testRunner.And("I have added the reference ..\\..\\packages\\NUnit.2.6.4\\lib\\nunit.framework.dll to " +
                     "foo.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 92
+#line 239
  testRunner.And("I have copied the reference ..\\..\\packages\\NUnit.2.6.4\\lib\\nunit.framework.dll to" +
                     " folder mocks", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 93
+#line 240
  testRunner.And(string.Format("I have specified {0} platform for assembly foo.tests", platform), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 94
+#line 241
  testRunner.And("I have compiled the assembly foo.tests to file mocks\\foo.tests.dll", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 95
+#line 242
  testRunner.And("I have added the assembly mocks\\foo.tests.dll to the list of testing assemblies", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 96
+#line 243
  testRunner.And("I have added the arg Where=cat!=CatA to NUnit console command line", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 97
+#line 244
  testRunner.And("I want to use CmdArguments type of TeamCity integration", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 98
+#line 245
  testRunner.And("I have added the arg workers=10 to NUnit console command line", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 99
+#line 246
  testRunner.And(string.Format("I have added the arg agents={0} to NUnit console command line", agents), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 100
+#line 247
  testRunner.And(string.Format("I have added the arg process={0} to NUnit console command line", process), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 101
+#line 248
  testRunner.And(string.Format("I have added the arg domain={0} to NUnit console command line", domain), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 102
+#line 249
  testRunner.When("I run NUnit console", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
-#line 103
+#line 250
  testRunner.Then("the exit code should be 0", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
-#line 104
+#line 251
  testRunner.And("the output should contain correct set of TeamCity service messages", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
-            TechTalk.SpecFlow.Table table2 = new TechTalk.SpecFlow.Table(new string[] {
+            TechTalk.SpecFlow.Table table3 = new TechTalk.SpecFlow.Table(new string[] {
                         "field",
                         "value"});
-            table2.AddRow(new string[] {
+            table3.AddRow(new string[] {
                         "Test Count",
                         "1"});
-            table2.AddRow(new string[] {
+            table3.AddRow(new string[] {
                         "Passed",
                         "1"});
-            table2.AddRow(new string[] {
+            table3.AddRow(new string[] {
                         "Failed",
                         "0"});
-            table2.AddRow(new string[] {
+            table3.AddRow(new string[] {
                         "Inconclusive",
                         "0"});
-            table2.AddRow(new string[] {
+            table3.AddRow(new string[] {
                         "Skipped",
                         "0"});
-#line 105
- testRunner.And("the Test Run Summary should has following:", ((string)(null)), table2, "And ");
+#line 252
+ testRunner.And("the Test Run Summary should has following:", ((string)(null)), table3, "And ");
 #line hidden
             this.ScenarioCleanup();
         }

--- a/src/nunit.integration.tests/RunTests.feature.cs
+++ b/src/nunit.integration.tests/RunTests.feature.cs
@@ -92,12 +92,6 @@ namespace nunit.integration.tests
         [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Multiple", "1", "AnyCpu", "ProjectFile", new string[0])]
         [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Multiple", "1", "AnyCpu", "ProjectFile", new string[0])]
         [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Multiple", "1", "AnyCpu", "ProjectFile", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Single", "10", "X86", "ProjectFile", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Single", "10", "X86", "ProjectFile", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version45", "Multiple", "Single", "10", "X86", "ProjectFile", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version40", "Multiple", "Single", "10", "X86", "ProjectFile", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Multiple", "10", "X86", "ProjectFile", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Multiple", "10", "X86", "ProjectFile", new string[0])]
         [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Single", "1", "X86", "ProjectFile", new string[0])]
         [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Single", "1", "X86", "ProjectFile", new string[0])]
         [NUnit.Framework.TestCaseAttribute("Version45", "Multiple", "Single", "1", "X86", "ProjectFile", new string[0])]
@@ -132,9 +126,6 @@ namespace nunit.integration.tests
         [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Multiple", "1", "AnyCpu", "CmdArguments", new string[0])]
         [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Multiple", "1", "AnyCpu", "CmdArguments", new string[0])]
         [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Multiple", "1", "AnyCpu", "CmdArguments", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version40", "Multiple", "Single", "10", "X86", "CmdArguments", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Multiple", "10", "X86", "CmdArguments", new string[0])]
-        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Multiple", "10", "X86", "CmdArguments", new string[0])]
         [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Single", "1", "X86", "CmdArguments", new string[0])]
         [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Single", "1", "X86", "CmdArguments", new string[0])]
         [NUnit.Framework.TestCaseAttribute("Version45", "Multiple", "Single", "1", "X86", "CmdArguments", new string[0])]
@@ -270,77 +261,77 @@ this.FeatureBackground();
         public virtual void UserRunsParallelizableTests(string frameworkVersion, string process, string domain, string agents, string platform, string[] exampleTags)
         {
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("User runs parallelizable tests", exampleTags);
-#line 128
+#line 119
 this.ScenarioSetup(scenarioInfo);
 #line 3
 this.FeatureBackground();
-#line 129
+#line 120
  testRunner.Given(string.Format("Framework version is {0}", frameworkVersion), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
-#line 130
+#line 121
  testRunner.And("I have added SuccessfulParallelizable method as SuccessfulParallelizable1 to the " +
                     "class Foo.Tests.UnitTests1 for foo1.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 131
+#line 122
  testRunner.And("I have added SuccessfulParallelizable method as SuccessfulParallelizable2 to the " +
                     "class Foo.Tests.UnitTests1 for foo1.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 132
+#line 123
  testRunner.And("I have added SuccessfulParallelizable method as SuccessfulParallelizable3 to the " +
                     "class Foo.Tests.UnitTests1 for foo1.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 133
+#line 124
  testRunner.And("I have added attribute [assembly: NUnit.Framework.Parallelizable] to the assembly" +
                     " foo1.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 134
+#line 125
  testRunner.And("I have added attribute [NUnit.Framework.Parallelizable] to the class Foo.Tests.Un" +
                     "itTests1 for foo1.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 135
+#line 126
  testRunner.And("I have added NUnit framework references to foo1.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 136
+#line 127
  testRunner.And("I have added SuccessfulParallelizable method as SuccessfulParallelizable4 to the " +
                     "class Foo.Tests.UnitTests1 for foo2.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 137
+#line 128
  testRunner.And("I have added SuccessfulParallelizable method as SuccessfulParallelizable5 to the " +
                     "class Foo.Tests.UnitTests1 for foo2.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 138
+#line 129
  testRunner.And("I have added SuccessfulParallelizable method as SuccessfulParallelizable6 to the " +
                     "class Foo.Tests.UnitTests1 for foo2.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 139
+#line 130
  testRunner.And("I have added attribute [assembly: NUnit.Framework.Parallelizable] to the assembly" +
                     " foo2.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 140
+#line 131
  testRunner.And("I have added attribute [NUnit.Framework.Parallelizable] to the class Foo.Tests.Un" +
                     "itTests1 for foo2.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 141
+#line 132
  testRunner.And("I have added NUnit framework references to foo2.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 142
+#line 133
  testRunner.And("I have created the folder mocks", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 143
+#line 134
  testRunner.And("I have copied NUnit framework references to folder mocks", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 144
+#line 135
  testRunner.And(string.Format("I have specified {0} platform for assembly foo1.tests", platform), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 145
+#line 136
  testRunner.And("I have compiled the assembly foo1.tests to file mocks\\foo1.tests.dll", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 146
+#line 137
  testRunner.And(string.Format("I have specified {0} platform for assembly foo2.tests", platform), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 147
+#line 138
  testRunner.And("I have compiled the assembly foo2.tests to file mocks\\foo2.tests.dll", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 148
+#line 139
  testRunner.And("I have added the assembly mocks\\foo1.tests.dll to the list of testing assemblies", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 149
+#line 140
  testRunner.And("I have added the assembly mocks\\foo2.tests.dll to the list of testing assemblies", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 150
+#line 141
  testRunner.And("I want to use CmdArguments type of TeamCity integration", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 151
+#line 142
  testRunner.And("I have added the arg workers=10 to NUnit console command line", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 152
+#line 143
  testRunner.And(string.Format("I have added the arg agents={0} to NUnit console command line", agents), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 153
+#line 144
  testRunner.And(string.Format("I have added the arg process={0} to NUnit console command line", process), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 154
+#line 145
  testRunner.And(string.Format("I have added the arg domain={0} to NUnit console command line", domain), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 155
+#line 146
  testRunner.When("I run NUnit console", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
-#line 156
+#line 147
  testRunner.Then("the exit code should be 0", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
-#line 157
+#line 148
  testRunner.And("the output should contain correct set of TeamCity service messages", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
             TechTalk.SpecFlow.Table table2 = new TechTalk.SpecFlow.Table(new string[] {
@@ -361,7 +352,7 @@ this.FeatureBackground();
             table2.AddRow(new string[] {
                         "Skipped",
                         "0"});
-#line 158
+#line 149
  testRunner.And("the Test Run Summary should has following:", ((string)(null)), table2, "And ");
 #line hidden
             this.ScenarioCleanup();
@@ -404,47 +395,47 @@ this.FeatureBackground();
         public virtual void UserRunsParallelizableTestsForNUnit2Framework(string frameworkVersion, string process, string domain, string agents, string platform, string[] exampleTags)
         {
             TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("User runs parallelizable tests for NUnit 2 framework", exampleTags);
-#line 209
+#line 192
 this.ScenarioSetup(scenarioInfo);
 #line 3
 this.FeatureBackground();
-#line 210
+#line 193
  testRunner.And("I have added successful method as SuccessfulTest to the class Foo.Tests.UnitTests" +
                     "1 for foo.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 211
+#line 194
  testRunner.And("I have added successfulCatA method as SuccessfulTestCatA to the class Foo.Tests.U" +
                     "nitTests1 for foo.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 212
+#line 195
  testRunner.And("I have created the folder mocks", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 213
+#line 196
  testRunner.And("I have added the reference ..\\..\\packages\\NUnit.2.6.4\\lib\\nunit.framework.dll to " +
                     "foo.tests", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 214
+#line 197
  testRunner.And("I have copied the reference ..\\..\\packages\\NUnit.2.6.4\\lib\\nunit.framework.dll to" +
                     " folder mocks", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 215
+#line 198
  testRunner.And(string.Format("I have specified {0} platform for assembly foo.tests", platform), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 216
+#line 199
  testRunner.And("I have compiled the assembly foo.tests to file mocks\\foo.tests.dll", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 217
+#line 200
  testRunner.And("I have added the assembly mocks\\foo.tests.dll to the list of testing assemblies", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 218
+#line 201
  testRunner.And("I have added the arg Where=cat!=CatA to NUnit console command line", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 219
+#line 202
  testRunner.And("I want to use CmdArguments type of TeamCity integration", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 220
+#line 203
  testRunner.And("I have added the arg workers=10 to NUnit console command line", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 221
+#line 204
  testRunner.And(string.Format("I have added the arg agents={0} to NUnit console command line", agents), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 222
+#line 205
  testRunner.And(string.Format("I have added the arg process={0} to NUnit console command line", process), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 223
+#line 206
  testRunner.And(string.Format("I have added the arg domain={0} to NUnit console command line", domain), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 224
+#line 207
  testRunner.When("I run NUnit console", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
-#line 225
+#line 208
  testRunner.Then("the exit code should be 0", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
-#line 226
+#line 209
  testRunner.And("the output should contain correct set of TeamCity service messages", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
             TechTalk.SpecFlow.Table table3 = new TechTalk.SpecFlow.Table(new string[] {
@@ -465,7 +456,7 @@ this.FeatureBackground();
             table3.AddRow(new string[] {
                         "Skipped",
                         "0"});
-#line 227
+#line 210
  testRunner.And("the Test Run Summary should has following:", ((string)(null)), table3, "And ");
 #line hidden
             this.ScenarioCleanup();

--- a/src/nunit.integration.tests/TeamCity.feature
+++ b/src/nunit.integration.tests/TeamCity.feature
@@ -275,8 +275,70 @@ Examples:
 	| Version40        |
 
 @teamcity
+Scenario Outline: NUnit sends TeamCity's service messages when I run many test for several assemblies for NUnit2
+	Given Framework version is <frameworkVersion>	
+	And I have added 100 successful methods as SuccessfulTest to the class Foo.Tests.UnitTests1 for foo.tests1
+	And I have added 100 successful methods as SuccessfulTest to the class Foo.Tests.UnitTests2 for foo.tests2
+	And I have created the folder mocks
+	And I have copied the reference ..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll to folder mocks
+	And I have added the reference ..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll to foo.tests1
+	And I have added the reference ..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll to foo.tests2
+	And I have compiled the assembly foo.tests1 to file mocks\foo.tests1.dll	
+	And I have compiled the assembly foo.tests2 to file mocks\foo.tests2.dll
+	And I have added the assembly mocks\foo.tests1.dll to the list of testing assemblies
+	And I have added the assembly mocks\foo.tests2.dll to the list of testing assemblies
+	And I want to use CmdArguments type of TeamCity integration
+	And I have added the arg workers=10 to NUnit console command line
+	And I have added the arg agents=<agents> to NUnit console command line
+	And I have added the arg process=<process> to NUnit console command line
+	And I have added the arg domain=<domain> to NUnit console command line
+	When I run NUnit console
+	Then the exit code should be 0
+	And the output should contain correct set of TeamCity service messages
+
+Examples:
+	| frameworkVersion | process   | domain   | agents |
+	| Version45        | InProcess | None     | 10     |
+	| Version40        | InProcess | None     | 10     |
+	| Version45        | Separate  | None     | 10     |
+	| Version40        | Separate  | None     | 10     |
+	| Version45        | Multiple  | None     | 10     |
+	| Version40        | Multiple  | None     | 10     |
+	| Version45        | InProcess | Single   | 10     |
+	| Version40        | InProcess | Single   | 10     |
+	| Version45        | Separate  | Single   | 10     |
+	| Version40        | Separate  | Single   | 10     |
+	| Version45        | Multiple  | Single   | 10     |
+	| Version40        | Multiple  | Single   | 10     |
+	| Version45        | InProcess | Multiple | 10     |
+	| Version40        | InProcess | Multiple | 10     |
+	| Version45        | Separate  | Multiple | 10     |
+	| Version40        | Separate  | Multiple | 10     |
+#	| Version45        | Multiple  | Multiple | 10     |
+#	| Version40        | Multiple  | Multiple | 10     |
+	| Version45        | InProcess | None     | 1      |
+	| Version40        | InProcess | None     | 1      |
+	| Version45        | Separate  | None     | 1      |
+	| Version40        | Separate  | None     | 1      |
+	| Version45        | Multiple  | None     | 1      |
+	| Version40        | Multiple  | None     | 1      |
+	| Version45        | InProcess | Single   | 1      |
+	| Version40        | InProcess | Single   | 1      |
+	| Version45        | Separate  | Single   | 1      |
+	| Version40        | Separate  | Single   | 1      |
+	| Version45        | Multiple  | Single   | 1      |
+	| Version40        | Multiple  | Single   | 1      |
+	| Version45        | InProcess | Multiple | 1      |
+	| Version40        | InProcess | Multiple | 1      |
+	| Version45        | Separate  | Multiple | 1      |
+	| Version40        | Separate  | Multiple | 1      |
+#	| Version45        | Multiple  | Multiple | 1      |
+#	| Version40        | Multiple  | Multiple | 1      |
+
+
+@teamcity
 @Ignore
-Scenario Outline: NUnit sends TeamCity's service messages for bunch of test from several assemblies for NUnit2
+Scenario Outline: NUnit sends TeamCity's service messages for bunch of test for several assemblies for NUnit2
 	Given Framework version is <frameworkVersion>
 	And I have created the folder mocks
 	And I have copied the reference ..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll to folder mocks	
@@ -297,22 +359,22 @@ Scenario Outline: NUnit sends TeamCity's service messages for bunch of test from
 	And the output should contain correct set of TeamCity service messages
 Examples:
 	| frameworkVersion | process   | domain   | agents |
-#	| Version45        | InProcess | None     | 10     |
-#	| Version40        | InProcess | None     | 10     |
-#	| Version45        | Separate  | None     | 10     |
-#	| Version40        | Separate  | None     | 10     |
-#	| Version45        | Multiple  | None     | 10     |
-#	| Version40        | Multiple  | None     | 10     |
-#	| Version45        | InProcess | Single   | 10     |
-#	| Version40        | InProcess | Single   | 10     |
-#	| Version45        | Separate  | Single   | 10     |
-#	| Version40        | Separate  | Single   | 10     |
-#	| Version45        | Multiple  | Single   | 10     |
-#	| Version40        | Multiple  | Single   | 10     |
-#	| Version45        | InProcess | Multiple | 10     |
-#	| Version40        | InProcess | Multiple | 10     |
-#	| Version45        | Separate  | Multiple | 10     |
-#	| Version40        | Separate  | Multiple | 10     |
+	| Version45        | InProcess | None     | 10     |
+	| Version40        | InProcess | None     | 10     |
+	| Version45        | Separate  | None     | 10     |
+	| Version40        | Separate  | None     | 10     |
+	| Version45        | Multiple  | None     | 10     |
+	| Version40        | Multiple  | None     | 10     |
+	| Version45        | InProcess | Single   | 10     |
+	| Version40        | InProcess | Single   | 10     |
+	| Version45        | Separate  | Single   | 10     |
+	| Version40        | Separate  | Single   | 10     |
+	| Version45        | Multiple  | Single   | 10     |
+	| Version40        | Multiple  | Single   | 10     |
+	| Version45        | InProcess | Multiple | 10     |
+	| Version40        | InProcess | Multiple | 10     |
+	| Version45        | Separate  | Multiple | 10     |
+	| Version40        | Separate  | Multiple | 10     |
 #	| Version45        | Multiple  | Multiple | 10     |
 #	| Version40        | Multiple  | Multiple | 10     |
 	| Version45        | InProcess | None     | 1      |

--- a/src/nunit.integration.tests/TeamCity.feature.cs
+++ b/src/nunit.integration.tests/TeamCity.feature.cs
@@ -1301,10 +1301,25 @@ this.FeatureBackground();
         }
         
         [NUnit.Framework.TestAttribute()]
-        [NUnit.Framework.DescriptionAttribute("NUnit sends TeamCity\'s service messages for bunch of test from several assemblies" +
-            " for NUnit2")]
-        [NUnit.Framework.IgnoreAttribute("Ignored scenario")]
+        [NUnit.Framework.DescriptionAttribute("NUnit sends TeamCity\'s service messages when I run many test for several assembli" +
+            "es for NUnit2")]
         [NUnit.Framework.CategoryAttribute("teamcity")]
+        [NUnit.Framework.TestCaseAttribute("Version45", "InProcess", "None", "10", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "None", "10", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "None", "10", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "None", "10", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Multiple", "None", "10", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Multiple", "None", "10", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "InProcess", "Single", "10", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Single", "10", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Single", "10", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Single", "10", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Multiple", "Single", "10", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Multiple", "Single", "10", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "InProcess", "Multiple", "10", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Multiple", "10", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Multiple", "10", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Multiple", "10", new string[0])]
         [NUnit.Framework.TestCaseAttribute("Version45", "InProcess", "None", "1", new string[0])]
         [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "None", "1", new string[0])]
         [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "None", "1", new string[0])]
@@ -1321,47 +1336,47 @@ this.FeatureBackground();
         [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Multiple", "1", new string[0])]
         [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Multiple", "1", new string[0])]
         [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Multiple", "1", new string[0])]
-        public virtual void NUnitSendsTeamCitySServiceMessagesForBunchOfTestFromSeveralAssembliesForNUnit2(string frameworkVersion, string process, string domain, string agents, string[] exampleTags)
+        public virtual void NUnitSendsTeamCitySServiceMessagesWhenIRunManyTestForSeveralAssembliesForNUnit2(string frameworkVersion, string process, string domain, string agents, string[] exampleTags)
         {
             string[] @__tags = new string[] {
-                    "teamcity",
-                    "Ignore"};
+                    "teamcity"};
             if ((exampleTags != null))
             {
                 @__tags = System.Linq.Enumerable.ToArray(System.Linq.Enumerable.Concat(@__tags, exampleTags));
             }
-            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("NUnit sends TeamCity\'s service messages for bunch of test from several assemblies" +
-                    " for NUnit2", @__tags);
-#line 279
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("NUnit sends TeamCity\'s service messages when I run many test for several assembli" +
+                    "es for NUnit2", @__tags);
+#line 278
 this.ScenarioSetup(scenarioInfo);
 #line 3
 this.FeatureBackground();
-#line 280
+#line 279
  testRunner.Given(string.Format("Framework version is {0}", frameworkVersion), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line 280
+ testRunner.And("I have added 100 successful methods as SuccessfulTest to the class Foo.Tests.Unit" +
+                    "Tests1 for foo.tests1", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line 281
- testRunner.And("I have created the folder mocks", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+ testRunner.And("I have added 100 successful methods as SuccessfulTest to the class Foo.Tests.Unit" +
+                    "Tests2 for foo.tests2", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line 282
+ testRunner.And("I have created the folder mocks", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 283
  testRunner.And("I have copied the reference ..\\..\\packages\\NUnit.2.6.4\\lib\\nunit.framework.dll to" +
                     " folder mocks", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 283
- testRunner.And("I have created assemblies according to NUnit2 test results ..\\..\\..\\testsData\\NUn" +
-                    "it2HugeTestResult.xml", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line 284
  testRunner.And("I have added the reference ..\\..\\packages\\NUnit.2.6.4\\lib\\nunit.framework.dll to " +
-                    "MAP.Common.Test", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+                    "foo.tests1", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line 285
- testRunner.And("I have compiled the assembly MAP.Common.Test to file mocks\\MAP.Common.Test.dll", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
-#line 286
  testRunner.And("I have added the reference ..\\..\\packages\\NUnit.2.6.4\\lib\\nunit.framework.dll to " +
-                    "MAP.Web.Test", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+                    "foo.tests2", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 286
+ testRunner.And("I have compiled the assembly foo.tests1 to file mocks\\foo.tests1.dll", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line 287
- testRunner.And("I have compiled the assembly MAP.Web.Test to file mocks\\MAP.Web.Test.dll", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+ testRunner.And("I have compiled the assembly foo.tests2 to file mocks\\foo.tests2.dll", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line 288
- testRunner.And("I have added the assembly mocks\\MAP.Common.Test.dll to the list of testing assemb" +
-                    "lies", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+ testRunner.And("I have added the assembly mocks\\foo.tests1.dll to the list of testing assemblies", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line 289
- testRunner.And("I have added the assembly mocks\\MAP.Web.Test.dll to the list of testing assemblie" +
-                    "s", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+ testRunner.And("I have added the assembly mocks\\foo.tests2.dll to the list of testing assemblies", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line 290
  testRunner.And("I want to use CmdArguments type of TeamCity integration", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line 291
@@ -1377,6 +1392,104 @@ this.FeatureBackground();
 #line 296
  testRunner.Then("the exit code should be 0", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
 #line 297
+ testRunner.And("the output should contain correct set of TeamCity service messages", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line hidden
+            this.ScenarioCleanup();
+        }
+        
+        [NUnit.Framework.TestAttribute()]
+        [NUnit.Framework.DescriptionAttribute("NUnit sends TeamCity\'s service messages for bunch of test for several assemblies " +
+            "for NUnit2")]
+        [NUnit.Framework.IgnoreAttribute("Ignored scenario")]
+        [NUnit.Framework.CategoryAttribute("teamcity")]
+        [NUnit.Framework.TestCaseAttribute("Version45", "InProcess", "None", "10", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "None", "10", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "None", "10", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "None", "10", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Multiple", "None", "10", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Multiple", "None", "10", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "InProcess", "Single", "10", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Single", "10", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Single", "10", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Single", "10", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Multiple", "Single", "10", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Multiple", "Single", "10", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "InProcess", "Multiple", "10", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Multiple", "10", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Multiple", "10", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Multiple", "10", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "InProcess", "None", "1", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "None", "1", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "None", "1", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "None", "1", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Multiple", "None", "1", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Multiple", "None", "1", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "InProcess", "Single", "1", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Single", "1", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Single", "1", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Single", "1", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Multiple", "Single", "1", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Multiple", "Single", "1", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "InProcess", "Multiple", "1", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "InProcess", "Multiple", "1", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version45", "Separate", "Multiple", "1", new string[0])]
+        [NUnit.Framework.TestCaseAttribute("Version40", "Separate", "Multiple", "1", new string[0])]
+        public virtual void NUnitSendsTeamCitySServiceMessagesForBunchOfTestForSeveralAssembliesForNUnit2(string frameworkVersion, string process, string domain, string agents, string[] exampleTags)
+        {
+            string[] @__tags = new string[] {
+                    "teamcity",
+                    "Ignore"};
+            if ((exampleTags != null))
+            {
+                @__tags = System.Linq.Enumerable.ToArray(System.Linq.Enumerable.Concat(@__tags, exampleTags));
+            }
+            TechTalk.SpecFlow.ScenarioInfo scenarioInfo = new TechTalk.SpecFlow.ScenarioInfo("NUnit sends TeamCity\'s service messages for bunch of test for several assemblies " +
+                    "for NUnit2", @__tags);
+#line 341
+this.ScenarioSetup(scenarioInfo);
+#line 3
+this.FeatureBackground();
+#line 342
+ testRunner.Given(string.Format("Framework version is {0}", frameworkVersion), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Given ");
+#line 343
+ testRunner.And("I have created the folder mocks", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 344
+ testRunner.And("I have copied the reference ..\\..\\packages\\NUnit.2.6.4\\lib\\nunit.framework.dll to" +
+                    " folder mocks", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 345
+ testRunner.And("I have created assemblies according to NUnit2 test results ..\\..\\..\\testsData\\NUn" +
+                    "it2HugeTestResult.xml", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 346
+ testRunner.And("I have added the reference ..\\..\\packages\\NUnit.2.6.4\\lib\\nunit.framework.dll to " +
+                    "MAP.Common.Test", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 347
+ testRunner.And("I have compiled the assembly MAP.Common.Test to file mocks\\MAP.Common.Test.dll", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 348
+ testRunner.And("I have added the reference ..\\..\\packages\\NUnit.2.6.4\\lib\\nunit.framework.dll to " +
+                    "MAP.Web.Test", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 349
+ testRunner.And("I have compiled the assembly MAP.Web.Test to file mocks\\MAP.Web.Test.dll", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 350
+ testRunner.And("I have added the assembly mocks\\MAP.Common.Test.dll to the list of testing assemb" +
+                    "lies", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 351
+ testRunner.And("I have added the assembly mocks\\MAP.Web.Test.dll to the list of testing assemblie" +
+                    "s", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 352
+ testRunner.And("I want to use CmdArguments type of TeamCity integration", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 353
+ testRunner.And("I have added the arg workers=10 to NUnit console command line", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 354
+ testRunner.And(string.Format("I have added the arg agents={0} to NUnit console command line", agents), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 355
+ testRunner.And(string.Format("I have added the arg process={0} to NUnit console command line", process), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 356
+ testRunner.And(string.Format("I have added the arg domain={0} to NUnit console command line", domain), ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
+#line 357
+ testRunner.When("I run NUnit console", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "When ");
+#line 358
+ testRunner.Then("the exit code should be 0", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "Then ");
+#line 359
  testRunner.And("the output should contain correct set of TeamCity service messages", ((string)(null)), ((TechTalk.SpecFlow.Table)(null)), "And ");
 #line hidden
             this.ScenarioCleanup();


### PR DESCRIPTION
Use test's id as a base for flowId for TC service messages in the case when NUnit 3 console runs test for nunit.framework.dll v2 in parallel mode
