### PR TITLE
Add another build to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: csharp
 sudo: false
-mono:
-  - latest
-  - 4.6.2
-os:
-  - linux
-  - osx
+matrix:
+  include:
+    - os: linux
+      mono: latest
+    - os: linux
+      mono: 4.6.2
+    - os: osx
+      mono: latest
 script:
   - ./build.sh --target "Travis"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,5 @@ mono:
 os:
   - linux
   - osx
-matrix:
-  exclude:
-    - os: osx
-      mono: 4.6.2
 script:
   - ./build.sh --target "Travis"


### PR DESCRIPTION
This makes the Travis CI build under both mono 4.6.2 and latest for linux and osx, a total of four builds. It's what we have done with all the other packages.