### PR TITLE
AssemblyInfo.cs: Set version 1.0.6.0

### DIFF
--- a/src/extension/Properties/AssemblyInfo.cs
+++ b/src/extension/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.4.0")]
-[assembly: AssemblyFileVersion("1.0.4.0")]
+[assembly: AssemblyVersion("1.0.6.0")]
+[assembly: AssemblyFileVersion("1.0.6.0")]


### PR DESCRIPTION
The 1.0.6 version of the nuget file contains a DLL that still claims to be 1.0.4.

This should really somehow be generated from the version number specified in the build scripts.