### PR TITLE
Fix for #82 and #84

### DIFF
--- a/src/extension/ServiceMessageFactory.cs
+++ b/src/extension/ServiceMessageFactory.cs
@@ -386,7 +386,11 @@
                             eventId.FullName.CopyTo(0, testDirNameChars, 0, eventId.FullName.Length);
                             for (var i = 0; i < testDirNameChars.Length; i++)
                             {
-                                if (_invalidChars.Contains(testDirNameChars[i]))
+                                var testDirNameChar = testDirNameChars[i];
+                                // TeamCity doesn't support artifacts with paths containing comma character: https://youtrack.jetbrains.com/issue/TW-19333
+                                // In order to make sure the artifacts are published correctly, we are getting rid of invalid characters,
+                                // and replacing the comma character with '_':
+                                if (_invalidChars.Contains(testDirNameChar) || testDirNameChar == ',')
                                 {
                                     testDirNameChars[i] = '_';
                                 }

--- a/src/extension/ServiceMessageFactory.cs
+++ b/src/extension/ServiceMessageFactory.cs
@@ -16,33 +16,7 @@
         private const string TcParseServiceMessagesInside = "tc:parseServiceMessagesInside";
         private static readonly IEnumerable<ServiceMessage> EmptyServiceMessages = new ServiceMessage[0];
         private static readonly Regex AttachmentDescriptionRegex = new Regex("(.*)=>(.+)", RegexOptions.Compiled);
-        private static readonly List<char> _invalidChars;
-
-        static ServiceMessageFactory()
-        {
-            var invalidPathChars = Path.GetInvalidPathChars();
-            var invalidFileNameChars = Path.GetInvalidFileNameChars();
-            _invalidChars = new List<char>(invalidPathChars.Length + invalidFileNameChars.Length + 1);
-            foreach (var c in invalidPathChars)
-            {
-                _invalidChars.Add(c);
-            }
-
-            foreach (var c in invalidFileNameChars)
-            {
-                if (_invalidChars.Contains(c))
-                {
-                    continue;
-                }
-
-                _invalidChars.Add(c);
-            }
-            // TeamCity doesn't support artifacts with paths containing comma character: https://youtrack.jetbrains.com/issue/TW-19333
-            // In order to make sure the artifacts are published correctly, we are getting rid of invalid characters,
-            // and the comma character is considered to be invalid:
-            _invalidChars.Add(',');
-        }
-
+        
         public ServiceMessageFactory(ITeamCityInfo teamCityInfo, ISuiteNameReplacer suiteNameReplacer)
         {
             _teamCityInfo = teamCityInfo;
@@ -386,18 +360,7 @@
 
                         if (artifactDir == null)
                         {
-                            var testDirNameChars = new char[eventId.FullName.Length];
-                            eventId.FullName.CopyTo(0, testDirNameChars, 0, eventId.FullName.Length);
-                            for (var i = 0; i < testDirNameChars.Length; i++)
-                            {
-                                if (_invalidChars.Contains(testDirNameChars[i]))
-                                {
-                                    testDirNameChars[i] = '_';
-                                }
-                            }
-
-                            var testDirName = new string(testDirNameChars);
-                            artifactDir = ".teamcity/NUnit/" + testDirName + "/" + Guid.NewGuid();
+                            artifactDir = ".teamcity/NUnit/" + Guid.NewGuid();
                         }
 
                         string artifactType;

--- a/src/extension/ServiceMessageFactory.cs
+++ b/src/extension/ServiceMessageFactory.cs
@@ -22,7 +22,7 @@
         {
             var invalidPathChars = Path.GetInvalidPathChars();
             var invalidFileNameChars = Path.GetInvalidFileNameChars();
-            _invalidChars = new List<char>(invalidPathChars.Length + invalidFileNameChars.Length);
+            _invalidChars = new List<char>(invalidPathChars.Length + invalidFileNameChars.Length + 1);
             foreach (var c in invalidPathChars)
             {
                 _invalidChars.Add(c);
@@ -37,6 +37,10 @@
 
                 _invalidChars.Add(c);
             }
+            // TeamCity doesn't support artifacts with paths containing comma character: https://youtrack.jetbrains.com/issue/TW-19333
+            // In order to make sure the artifacts are published correctly, we are getting rid of invalid characters,
+            // and the comma character is considered to be invalid:
+            _invalidChars.Add(',');
         }
 
         public ServiceMessageFactory(ITeamCityInfo teamCityInfo, ISuiteNameReplacer suiteNameReplacer)
@@ -386,11 +390,7 @@
                             eventId.FullName.CopyTo(0, testDirNameChars, 0, eventId.FullName.Length);
                             for (var i = 0; i < testDirNameChars.Length; i++)
                             {
-                                var testDirNameChar = testDirNameChars[i];
-                                // TeamCity doesn't support artifacts with paths containing comma character: https://youtrack.jetbrains.com/issue/TW-19333
-                                // In order to make sure the artifacts are published correctly, we are getting rid of invalid characters,
-                                // and replacing the comma character with '_':
-                                if (_invalidChars.Contains(testDirNameChar) || testDirNameChar == ',')
+                                if (_invalidChars.Contains(testDirNameChars[i]))
                                 {
                                     testDirNameChars[i] = '_';
                                 }


### PR DESCRIPTION
This is a simple fix for #82 and #84
The idea is that we don't need to use the test name when creating a directory for the artifact. In any case, such artifacts are published into a hidden folder `.teamcity/NUnit/`, so it is enough to use just `Guid.NewGuid()` instead of using trimmed test name with escaped special characters.